### PR TITLE
Allow transcription and translation HTML to be requested as XHTML or HTML

### DIFF
--- a/docker/docker-compose_usage-example.yml
+++ b/docker/docker-compose_usage-example.yml
@@ -6,6 +6,7 @@ services:
     environment:
       CUDL_SERVICES_DATA_LOCATION: /var/lib/cudl/cudl-data
       CUDL_SERVICES_XTF_URL: http://xtf:8080/
+      CUDL_SERVICES_TEI_HTML_URL: https://cudl-transcriptions-staging.s3-eu-west-1.amazonaws.com/
       CUDL_SERVICES_XTF_INDEX_PATH: /var/lib/xtf/index/default
       CUDL_SERVICES_DB_HOST: db
       CUDL_SERVICES_DB_NAME: cudlservices

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "morgan": "^1.10.0",
         "nested-error-stacks": "^2.1.0",
         "parse-http-header": "^1",
+        "parse5": "^6.0.1",
         "passport": "^0.4.1",
         "passport-accesstoken": "~0.1.0",
         "passport-token": "^0.2.0",
@@ -44,7 +45,8 @@
         "uri-js": "^4.4.1",
         "xml2js": "^0.4.23",
         "xmlbuilder": "^15.1.1",
-        "xmldom": "^0.5.0"
+        "xmldom": "^0.5.0",
+        "xmlserializer": "^0.6.1"
       },
       "bin": {
         "cudl-services": "bin/cudl-services.js"
@@ -63,6 +65,7 @@
         "@types/morgan": "^1.9.2",
         "@types/nested-error-stacks": "^2.1.0",
         "@types/node": "^14.14.22",
+        "@types/parse5": "^6.0.0",
         "@types/passport": "^1.0.5",
         "@types/pg": "^7.14.9",
         "@types/qs": "^6.9.5",
@@ -73,6 +76,7 @@
         "@types/tmp": "^0.2.0",
         "@types/xml2js": "^0.4.7",
         "@types/xmldom": "^0.1.30",
+        "@types/xmlserializer": "^0.6.2",
         "collapse-whitespace": "^1.1.7",
         "crypto-random-string": "^3.3.1",
         "get-port": "^5.1.1",
@@ -3231,6 +3235,7 @@
         "jest-resolve": "^26.6.2",
         "jest-util": "^26.6.2",
         "jest-worker": "^26.6.2",
+        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -3579,6 +3584,9 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.6"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -3869,6 +3877,9 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.6"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -4407,6 +4418,21 @@
       "version": "0.1.30",
       "resolved": "https://registry.npmjs.org/@types/xmldom/-/xmldom-0.1.30.tgz",
       "integrity": "sha512-edqgAFXMEtVvaBZ3YnhamvmrHjoYpuxETmnb0lbTZmf/dXpAsO9ZKotUO4K2rn2SIZBDFCMOuA7fOe0H6dRZcA==",
+      "dev": true
+    },
+    "node_modules/@types/xmlserializer": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@types/xmlserializer/-/xmlserializer-0.6.2.tgz",
+      "integrity": "sha512-b4SMcuaAciMp/C5Lkg2uF4arBt7Unv/HreCNQ99Cs961ZuPFwKju6wY/Q4eLkx49SJhKTWo4ahooqpFLR2ZZFg==",
+      "dev": true,
+      "dependencies": {
+        "parse5": "^5.1.0"
+      }
+    },
+    "node_modules/@types/xmlserializer/node_modules/parse5": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+      "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -6846,7 +6872,8 @@
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -10011,6 +10038,7 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
+        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",
@@ -10743,6 +10771,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dependencies": {
+        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -10790,6 +10819,9 @@
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.9"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.9"
       }
@@ -11547,6 +11579,9 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.6"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -16277,6 +16312,11 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/xmlserializer": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/xmlserializer/-/xmlserializer-0.6.1.tgz",
+      "integrity": "sha512-FNb0eEqqUUbnuvxuHqNuKH8qCGKqxu+558Zi8UzOoQk8Z9LdvpONK+v7m3gpKVHrk5Aq+0nNLsKxu/6OYh7Umw=="
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -20161,6 +20201,23 @@
       "resolved": "https://registry.npmjs.org/@types/xmldom/-/xmldom-0.1.30.tgz",
       "integrity": "sha512-edqgAFXMEtVvaBZ3YnhamvmrHjoYpuxETmnb0lbTZmf/dXpAsO9ZKotUO4K2rn2SIZBDFCMOuA7fOe0H6dRZcA==",
       "dev": true
+    },
+    "@types/xmlserializer": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@types/xmlserializer/-/xmlserializer-0.6.2.tgz",
+      "integrity": "sha512-b4SMcuaAciMp/C5Lkg2uF4arBt7Unv/HreCNQ99Cs961ZuPFwKju6wY/Q4eLkx49SJhKTWo4ahooqpFLR2ZZFg==",
+      "dev": true,
+      "requires": {
+        "parse5": "^5.1.0"
+      },
+      "dependencies": {
+        "parse5": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+          "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+          "dev": true
+        }
+      }
     },
     "@types/yargs": {
       "version": "15.0.13",
@@ -25611,6 +25668,7 @@
       "integrity": "sha512-HcZ0RWQRuJfpPiaHyFQJzcym+/dDIVUPwUAXWoub/C4GkGu+mPjp8vqK6g0FxokCnnI2TK0gZTza2IDfiNNscQ==",
       "peer": true,
       "requires": {
+        "@babel/core": "^7.0.0",
         "@babel/plugin-proposal-class-properties": "^7.0.0",
         "@babel/plugin-proposal-export-default-from": "^7.0.0",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
@@ -25657,6 +25715,7 @@
       "integrity": "sha512-K1sHO3ODBFCr7uEiCQ4RvVr+cQg0EHQF8ChVPnecGh/WDD8udrTq9ECwB0dRfMjAvlsHtRUlJm6ZSI8UPgum2w==",
       "peer": true,
       "requires": {
+        "@babel/core": "^7.0.0",
         "babel-preset-fbjs": "^3.3.0",
         "metro-babel-transformer": "0.64.0",
         "metro-react-native-babel-preset": "0.64.0",
@@ -29419,6 +29478,11 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
       "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA=="
+    },
+    "xmlserializer": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/xmlserializer/-/xmlserializer-0.6.1.tgz",
+      "integrity": "sha512-FNb0eEqqUUbnuvxuHqNuKH8qCGKqxu+558Zi8UzOoQk8Z9LdvpONK+v7m3gpKVHrk5Aq+0nNLsKxu/6OYh7Umw=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "morgan": "^1.10.0",
     "nested-error-stacks": "^2.1.0",
     "parse-http-header": "^1",
+    "parse5": "^6.0.1",
     "passport": "^0.4.1",
     "passport-accesstoken": "~0.1.0",
     "passport-token": "^0.2.0",
@@ -56,7 +57,8 @@
     "uri-js": "^4.4.1",
     "xml2js": "^0.4.23",
     "xmlbuilder": "^15.1.1",
-    "xmldom": "^0.5.0"
+    "xmldom": "^0.5.0",
+    "xmlserializer": "^0.6.1"
   },
   "peerDependencies": {
     "qs": "^6"
@@ -75,6 +77,7 @@
     "@types/morgan": "^1.9.2",
     "@types/nested-error-stacks": "^2.1.0",
     "@types/node": "^14.14.22",
+    "@types/parse5": "^6.0.0",
     "@types/passport": "^1.0.5",
     "@types/pg": "^7.14.9",
     "@types/qs": "^6.9.5",
@@ -85,6 +88,7 @@
     "@types/tmp": "^0.2.0",
     "@types/xml2js": "^0.4.7",
     "@types/xmldom": "^0.1.30",
+    "@types/xmlserializer": "^0.6.2",
     "collapse-whitespace": "^1.1.7",
     "crypto-random-string": "^3.3.1",
     "get-port": "^5.1.1",

--- a/src/routes/transcription-impl.ts
+++ b/src/routes/transcription-impl.ts
@@ -1,4 +1,4 @@
-import {Request, RequestHandler, Response, Router} from 'express';
+import express, {Request, RequestHandler, Response, Router} from 'express';
 import expressAsyncHandler from 'express-async-handler';
 import {PathParams} from 'express-serve-static-core';
 import {getReasonPhrase, StatusCodes} from 'http-status-codes';
@@ -399,3 +399,15 @@ export function createDefaultResourceURLRewriter(options?: {
     return relativeResolve(baseResourceURL, rootRelativeResourceURL);
   };
 }
+
+export const overrideAcceptHeaderFromQueryParameterMiddleware: express.Handler = (
+  req,
+  res,
+  next
+) => {
+  const overriddenAccept = req.query['Accept'];
+  if (typeof overriddenAccept === 'string') {
+    req.headers.accept = overriddenAccept;
+  }
+  next();
+};

--- a/src/routes/transcription.ts
+++ b/src/routes/transcription.ts
@@ -23,6 +23,7 @@ import {
   teiHtmlServiceHandler,
 } from './cudl-tei-html-service-impl';
 import expressAsyncHandler = require('express-async-handler');
+import {negotiateHtmlResponseType} from '../html';
 
 interface TranscriptionEndpoint<T> {
   path: string;
@@ -179,7 +180,7 @@ function attachTranscriptionHandler<T>(
 
 class InvalidTranscriptionOptionsError extends Error {}
 
-function createTranscriptionHandler<T>(
+export function createTranscriptionHandler<T>(
   transcriptionService: TranscriptionService<T>,
   extractOptions: (req: Request) => T
 ) {
@@ -196,7 +197,10 @@ function createTranscriptionHandler<T>(
 
     try {
       const html = await transcriptionService.getTranscription(options);
-      res.type('html').end(html);
+      const {html: negotiatedHtml, contentType} = negotiateHtmlResponseType(
+        req
+      )(html);
+      res.type(contentType).send(negotiatedHtml);
       return;
     } catch (e) {
       let status, msg;

--- a/src/routes/transcription.ts
+++ b/src/routes/transcription.ts
@@ -12,7 +12,10 @@ import {
   requireRequestParam,
   requireRequestParams,
 } from '../util';
-import {delegateToExternalHTML} from './transcription-impl';
+import {
+  delegateToExternalHTML,
+  overrideAcceptHeaderFromQueryParameterMiddleware,
+} from './transcription-impl';
 import {
   CUDLFormat,
   CUDLMetadataRepository,
@@ -66,6 +69,8 @@ export function getRoutes(options: GetRoutesOptions): express.Handler {
       router: () => Router(),
     }
   );
+
+  router.use(overrideAcceptHeaderFromQueryParameterMiddleware);
 
   router.use(
     teiHtmlServiceHandler(TeiHtmlServiceContent.TRANSCRIPTION, teiServiceURL)

--- a/src/routes/translation.ts
+++ b/src/routes/translation.ts
@@ -1,6 +1,9 @@
 import express, {Request} from 'express';
 import {applyLazyDefaults} from '../util';
-import {delegateToExternalHTML} from './transcription-impl';
+import {
+  delegateToExternalHTML,
+  overrideAcceptHeaderFromQueryParameterMiddleware,
+} from './transcription-impl';
 import {URL} from 'url';
 import {ValueError} from '../errors';
 import {
@@ -21,6 +24,8 @@ export function getRoutes(options: GetRoutesOptions): express.Handler {
       router: () => express.Router(),
     }
   );
+
+  router.use(overrideAcceptHeaderFromQueryParameterMiddleware);
 
   router.use(
     teiHtmlServiceHandler(TeiHtmlServiceContent.TRANSLATION, teiServiceURL)

--- a/test/__snapshots__/html.test.ts.snap
+++ b/test/__snapshots__/html.test.ts.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+exports[`serialiseXHTML returns expected XHTML for example 0 1`] = `
+"<html xmlns=\\"http://www.w3.org/1999/xhtml\\"><head>
+        <script src=\\"//other.example.com/js/foo.js\\"/>
+        <script src=\\"/things/js/bar.js\\"/>
+        <script src=\\"js/baz.js\\"/>
+        <link href=\\"http://other.example.com/css/foo.css\\" rel=\\"stylesheet\\" type=\\"text/css\\"/>
+        <link href=\\"/things/css/bar.css\\" rel=\\"stylesheet\\" type=\\"text/css\\"/>
+        <link href=\\"css/baz.css\\" rel=\\"stylesheet\\" type=\\"text/css\\"/>
+    </head>
+<body>
+</body></html>"
+`;
+
+exports[`serialiseXHTML returns expected XHTML for example 1 1`] = `
+"<html xmlns=\\"http://www.w3.org/1999/xhtml\\"><head>
+  <meta http-equiv=\\"Content-Type\\" content=\\"text/html; charset=UTF-8\\"/>
+  <title>Example Transcription</title>
+  <link href=\\"/cudl-resources/stylesheets/texts.css\\" rel=\\"stylesheet\\" type=\\"text/css\\"/>
+</head>
+<body>
+  <h1>Example</h1>
+  <p>This is not a real transcription.</p>
+
+
+</body></html>"
+`;

--- a/test/routes/transcription.test.ts
+++ b/test/routes/transcription.test.ts
@@ -6,7 +6,7 @@ import {get} from 'superagent';
 import request from 'supertest';
 import {mocked} from 'ts-jest/utils';
 import {promisify} from 'util';
-import {parseHTML} from '../../src/html';
+import {HTMLType, parseHTML} from '../../src/html';
 import {
   getRoutes,
   rewriteHtmlResourceUrls,
@@ -288,6 +288,21 @@ describe('transcription routes', () => {
         );
       }
     });
+
+    test.each([
+      [HTMLType.HTML, `${HTMLType.HTML},HTMLType.XHTML`],
+      [HTMLType.XHTML, `${HTMLType.XHTML},HTMLType.HTML`],
+    ])(
+      'responds with %s from HTML endpoint when client accepts %j',
+      async (expectedType, acceptedTypes) => {
+        const response = await request(app)
+          .get('/bezae/diplomatic/Bezae-Greek.xml/MS-NN-00002-00041/3v/3v')
+          .accept(acceptedTypes);
+
+        expect(response.ok).toBeTruthy();
+        expect(response.type).toBe(expectedType);
+      }
+    );
   });
 
   describe('utilities', () => {


### PR DESCRIPTION
This PR implements content negotiation for the `/v1/transcription/*` and `/v1/translation/*` HTML endpoints, allowing XHTML to be requested via the `Accept` header. By default, HTML is returned if no preference is specified. 

In addition, clients can communicate content-type preferences via the `Accept` query parameter, which will override the value of any `Accept` header they specify.

Both of these features are required by the XTF XSLT indexer, as it doesn't support parsing HTML, and also doesn't support specifying request headers when performing HTTP requests. (And also claims to 'Accept` HTML in preference to XML in its HTTP requests, despite not being able to parse HTML...).