### PR TITLE
fix: don't nest partial metadata in similarity responses

### DIFF
--- a/src/routes/similarity-impl.ts
+++ b/src/routes/similarity-impl.ts
@@ -43,10 +43,10 @@ export async function embedMetadata(
 
       const meta =
         level === 'full'
-          ? metadata
+          ? {metadata}
           : _reduceMetadata(metadata, hit.structureNodeId);
 
-      return {...hit, metadata: meta};
+      return {...hit, ...meta};
     })
   );
 

--- a/test/routes/similarity-impl.test.ts
+++ b/test/routes/similarity-impl.test.ts
@@ -116,13 +116,15 @@ describe('similarity route implementation', () => {
             ID: 'a',
             score: 42,
             structureNodeId: '3',
-            metadata: {...meta['a'], reduced: true},
+            ...meta['a'],
+            reduced: true,
           },
           {
             ID: 'b',
             score: 42,
             structureNodeId: '4',
-            metadata: {...meta['b'], reduced: true},
+            ...meta['b'],
+            reduced: true,
           },
         ],
       });


### PR DESCRIPTION
The behaviour of partial metadata embedding in the "hit" objects of
similarity JSON responses was different to the old version of services.
Previously only full item metadata was nested under a `metadata` key,
partial metadata keys were merged directly into the hit. This change
restores the old behaviour.